### PR TITLE
Add pipeline source configuration and default filters

### DIFF
--- a/src/main/java/io/jenkins/plugins/sample/DxGlobalConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/sample/DxGlobalConfiguration.java
@@ -15,12 +15,25 @@ import org.kohsuke.stapler.StaplerRequest;
 public class DxGlobalConfiguration extends GlobalConfiguration {
 
     private String dxBaseUrl;
-    private String includeRepoPattern;
-    private String includeJobPattern;
-    private String includeBranchPattern;
+    private String includeRepoPattern = ".*";
+    private String includeJobPattern = ".*";
+    private String includeBranchPattern = ".*";
+    private String pipelineSource = "Jenkins";
 
     public DxGlobalConfiguration() {
         load();
+        if (includeRepoPattern == null || includeRepoPattern.isEmpty()) {
+            includeRepoPattern = ".*";
+        }
+        if (includeJobPattern == null || includeJobPattern.isEmpty()) {
+            includeJobPattern = ".*";
+        }
+        if (includeBranchPattern == null || includeBranchPattern.isEmpty()) {
+            includeBranchPattern = ".*";
+        }
+        if (pipelineSource == null || pipelineSource.isEmpty()) {
+            pipelineSource = "Jenkins";
+        }
     }
 
     public static DxGlobalConfiguration get() {
@@ -68,6 +81,17 @@ public class DxGlobalConfiguration extends GlobalConfiguration {
     @DataBoundSetter
     public void setIncludeBranchPattern(@Nullable String includeBranchPattern) {
         this.includeBranchPattern = includeBranchPattern;
+        save();
+    }
+
+    @Nullable
+    public String getPipelineSource() {
+        return pipelineSource;
+    }
+
+    @DataBoundSetter
+    public void setPipelineSource(@Nullable String pipelineSource) {
+        this.pipelineSource = pipelineSource;
         save();
     }
 

--- a/src/main/java/io/jenkins/plugins/sample/DxRunListener.java
+++ b/src/main/java/io/jenkins/plugins/sample/DxRunListener.java
@@ -153,7 +153,7 @@ public class DxRunListener extends RunListener<Run<?, ?>> {
 
         JSONObject payload = new JSONObject();
         payload.put("pipeline_name", pipelineName);
-        payload.put("pipeline_source", "jenkins");
+        payload.put("pipeline_source", config.getPipelineSource());
         payload.put("reference_id", referenceId);
         payload.put("source_id", sourceId);
         payload.put("started_at", start);

--- a/src/main/resources/io/jenkins/plugins/sample/DxGlobalConfiguration/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/sample/DxGlobalConfiguration/config.jelly
@@ -4,6 +4,9 @@
     <f:entry title="DX API Base URL" field="dxBaseUrl" description="Base URL for the DX API, e.g. https://dx.example.com">
       <f:textbox/>
     </f:entry>
+    <f:entry title="Pipeline Source" field="pipelineSource" description="Value sent as pipeline_source to DX">
+      <f:textbox/>
+    </f:entry>
     <f:entry title="Include Repository (regex)" field="includeRepoPattern" description="Match the full repository name 'owner/repo'. Example: ^my-org/.+$">
       <f:textbox/>
     </f:entry>


### PR DESCRIPTION
## Summary
- allow configuration of pipeline source with default `Jenkins`
- default repo, job, and branch filters to match all (`.*`)
- expose pipeline source field on global configuration

## Testing
- `mvn -q -ntp test` *(fails: Non-resolvable parent POM for io.jenkins.plugins:dx-data-sharer)*

------
https://chatgpt.com/codex/tasks/task_e_68acc931b40c8322932669f9f63fddbe